### PR TITLE
修复GetNodeText的一个BUG

### DIFF
--- a/GAutomatorSdk/UnitySDK/NGUI/4.x/U3DAutomation/U3DAutomation/Handler/CommandHandler.cs
+++ b/GAutomatorSdk/UnitySDK/NGUI/4.x/U3DAutomation/U3DAutomation/Handler/CommandHandler.cs
@@ -447,6 +447,7 @@ namespace WeTest.U3DAutomation
                     //返回无该gameobject
                     command.status = ResponseStatus.GAMEOBJ_NOT_EXIST;
                     command.sendObj = "GameObject " + instance + " is not exists";
+                    CommandDispatcher.SendCommand(command);
                     return;
                 }
                 string text = uiHelper.GetText(gameObject);

--- a/GAutomatorSdk/UnitySDK/UGUI/4.x/U3DAutomation/U3DAutomation/Handler/CommandHandler.cs
+++ b/GAutomatorSdk/UnitySDK/UGUI/4.x/U3DAutomation/U3DAutomation/Handler/CommandHandler.cs
@@ -459,6 +459,7 @@ namespace WeTest.U3DAutomation
                     //返回无该gameobject
                     command.status = ResponseStatus.GAMEOBJ_NOT_EXIST;
                     command.sendObj = "GameObject " + instance + " is not exists";
+                    CommandDispatcher.SendCommand(command);
                     return;
                 }
                 string text = uiHelper.GetText(gameObject);


### PR DESCRIPTION
在测试过程中，有同事在使用GetNodeText的时候，会因为玩家死亡等条件使得需要GetText的Element被销毁。 因为return前没有SendCommand，结果会导致SDK无响应而中断测试流程。
修复建议是在return前发送Command